### PR TITLE
Avoid DoS

### DIFF
--- a/gck-rpc-dispatch.c
+++ b/gck-rpc-dispatch.c
@@ -2077,7 +2077,7 @@ static int write_all(int sock, unsigned char *data, size_t len)
 
 	while (len > 0) {
 
-                r = send(sock, (void *)data, len, 0);
+                r = send(sock, (void *)data, len, MSG_NOSIGNAL);
 
 		if (r == -1) {
 			if (errno == EPIPE) {


### PR DESCRIPTION
This is necessary to not get a SIGPIPE on write failures (easy DoS
of the pkcs11-daemon - client just need to close the connection at
the wrong moment).
