### PR TITLE
bugfix: gck-rpc-util.c: for loop should check count not array

### DIFF
--- a/gck-rpc-util.c
+++ b/gck-rpc-util.c
@@ -76,7 +76,7 @@ gck_rpc_mechanism_list_purge(CK_MECHANISM_TYPE_PTR mechs, CK_ULONG * n_mechs)
 	assert(mechs);
 	assert(n_mechs);
 
-	for (i = 0; i < (int)(*mechs); ++i) {
+	for (i = 0; i < (int)(*n_mechs); ++i) {
 		if (!gck_rpc_mechanism_has_no_parameters(mechs[i]) &&
 		    !gck_rpc_mechanism_has_sane_parameters(mechs[i])) {
 


### PR DESCRIPTION
for loop should check count not array