### PR TITLE
OSX port and OpenSSL v1.1 compatibility

### DIFF
--- a/BUILD.rst
+++ b/BUILD.rst
@@ -1,0 +1,17 @@
+
+Building PKCS11 Proxy
+=====================
+
+Make sure the relevant OpenSSL dev tools are installed.
+For OS/X, just do :-
+brew install openssl
+
+cmake .
+
+make
+
+make install
+
+On Linux RPM based systems, you can also create an RPM package via :-
+
+make package

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,13 @@ endif(COMMAND cmake_policy)
 
 project (pkcs11 C)
 
+set(VERSION "1.0.0")
+
 set(PKCS11_PROXY_SRCS gck-rpc-module.c gck-rpc-message.c gck-rpc-util.c egg-buffer.c gck-rpc-tls-psk.c)
 set(PKCS11_DAEMON_SRCS egg-buffer.c gck-rpc-daemon-standalone.c gck-rpc-dispatch.c gck-rpc-message.c gck-rpc-util.c syscall-reporter.c syscall-names.h gck-rpc-tls-psk.c)
+
+# Uncomment for a debug build
+#set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 -ggdb")
 
 # Search OpenSSL
 if (APPLE)
@@ -65,3 +70,20 @@ add_custom_command(
    OUTPUT syscall-names.h 
    COMMAND ${CMAKE_SOURCE_DIR}/mksyscalls.sh
    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+set(CPACK_PACKAGE_VERSION ${VERSION})
+set(CPACK_GENERATOR "RPM")
+set(CPACK_PACKAGE_NAME "pkcs11_proxy")
+set(CPACK_PACKAGE_RELEASE 1)
+set(CPACK_RPM_PACKAGE_RELEASE 1)
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "PKCS#11 Proxy")
+set(CPACK_PACKAGE_CONTACT "Jon Scobie")
+set(CPACK_PACKAGE_VENDOR "Callsign Inc")
+set(CPACK_RPM_PACKAGE_LICENSE "GPL v2")
+set(CPACK_RPM_PACKAGE_AUTOREQPROV " no")
+set(CPACK_PACKAGE_DESCRIPTION_FILE, "${CMAKE_CURRENT_BINARY_DIR}/USAGE")
+set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
+set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_PACKAGE_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}")
+set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/usr/local;/usr/local/lib;/usr/local/bin")
+set(CPACK_SOURCE_GENERATOR "RPM")
+include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,23 @@ project (pkcs11 C)
 set(PKCS11_PROXY_SRCS gck-rpc-module.c gck-rpc-message.c gck-rpc-util.c egg-buffer.c gck-rpc-tls-psk.c)
 set(PKCS11_DAEMON_SRCS egg-buffer.c gck-rpc-daemon-standalone.c gck-rpc-dispatch.c gck-rpc-message.c gck-rpc-util.c syscall-reporter.c syscall-names.h gck-rpc-tls-psk.c)
 
+# Search OpenSSL
+if (APPLE)
+    set(ENV{PKG_CONFIG_PATH} "/usr/local/opt/openssl/lib/pkgconfig/:$ENV{PKG_CONFIG_PATH}")
+endif()
+
+find_package(PkgConfig REQUIRED)
+pkg_search_module(OPENSSL REQUIRED openssl)
+
+if( OPENSSL_FOUND )
+
+    include_directories(${OPENSSL_INCLUDE_DIRS})
+    link_directories(${OPENSSL_LIBRARY_DIRS})
+    message(STATUS "Using OpenSSL ${OPENSSL_VERSION}")
+else()
+    # Error; with REQUIRED, pkg_search_module() will throw an error by it's own
+endif()
+
 add_definitions(-Wall)
 add_library(pkcs11-proxy SHARED ${PKCS11_PROXY_SRCS})
 
@@ -34,7 +51,12 @@ if (WIN32)
 endif (WIN32)
 
 target_link_libraries (pkcs11-proxy pthread ssl crypto)
-target_link_libraries (pkcs11-daemon dl pthread ssl crypto seccomp)
+
+if (APPLE)
+    target_link_libraries (pkcs11-daemon dl pthread ssl crypto)
+else()
+    target_link_libraries (pkcs11-daemon dl pthread ssl crypto seccomp)
+endif()
 
 install_targets (/lib pkcs11-proxy)
 install_targets (/bin pkcs11-daemon)

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,7 @@ This fork has the following additional features:
 - seccomp syscall filtering (only tested in inetd-mode)
 - getaddrinfo support for IPv6, fallback and DNS resolution
 - TLS-PSK support to optionally encrypt communication
+- OS/X build support 
 
 Plus a number of important bug fixes. This version passes the SoftHSM test
 suite.

--- a/config.h
+++ b/config.h
@@ -11,6 +11,10 @@
 //# define DEBUG_SECCOMP
 //# define SECCOMP
 
+#ifdef __APPLE__
+# define MSG_NOSIGNAL SO_NOSIGPIPE
+#endif
+
 #ifdef __MINGW32__
 
 # include <stdint.h>
@@ -34,7 +38,6 @@ enum  {
 	SHUT_RDWR /* No more receptions or transmissions.  */
 };
 
-#ifdef  __MINGW32__
 static inline int inet_aton(const char * cp, struct in_addr *pin)
 {
         int rc = inet_addr(cp);
@@ -44,7 +47,6 @@ static inline int inet_aton(const char * cp, struct in_addr *pin)
         pin->s_addr = rc;
         return 1;
 }
-#endif
 
 #endif
 

--- a/gck-rpc-dispatch.c
+++ b/gck-rpc-dispatch.c
@@ -2198,7 +2198,7 @@ static int write_all(CallState *cs, void *data, size_t len)
 		if (cs->tls)
 			r = gck_rpc_tls_write_all(cs->tls, (void *) data, len);
 		else
-                        r = send(cs->sock, data, len, MSG_NOSIGNAL);
+            r = send(cs->sock, data, len, MSG_NOSIGNAL);
 
 		if (r == -1) {
 			if (errno == EPIPE) {
@@ -2371,8 +2371,8 @@ void gck_rpc_layer_accept(GckRpcTlsPskState *tls)
 	}
 
 	ds->cs.sock = new_fd;
-        ds->cs.read = &read_all;
-        ds->cs.write = &write_all;
+        ds->cs.read = (int (*)(void *, unsigned char *, unsigned long))&read_all;
+        ds->cs.write = (int (*)(void *, unsigned char *, unsigned long))&write_all;
 	ds->cs.addr = addr;
 	ds->cs.addrlen = addrlen;
 	ds->cs.tls = tls;
@@ -2409,8 +2409,8 @@ void gck_rpc_layer_inetd(CK_FUNCTION_LIST_PTR module)
 
    memset(&cs, 0, sizeof(cs));
    cs.sock = STDIN_FILENO;
-   cs.read = &_inetd_read;
-   cs.write = &_inetd_write;
+   cs.read = (int (*)(void *, unsigned char *, unsigned long))&_inetd_read;
+   cs.write = (int (*)(void *, unsigned char *, unsigned long))&_inetd_write;
 
    pkcs11_module = module;
 

--- a/gck-rpc-util.c
+++ b/gck-rpc-util.c
@@ -96,6 +96,7 @@ int gck_rpc_mechanism_has_sane_parameters(CK_MECHANISM_TYPE type)
 	switch (type) {
 	case CKM_RSA_PKCS_OAEP:
 	case CKM_RSA_PKCS_PSS:
+    case CKM_AES_CBC_PAD:
 		return 1;
 	default:
 		return 0;

--- a/mksyscalls.sh
+++ b/mksyscalls.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
-(echo "static const char *syscall_names[] = {"
+(echo "#ifdef SECCOMP"
+echo "static const char *syscall_names[] = {"
 echo "#include <sys/syscall.h>" | cpp -dM | grep '^#define __NR_' | LC_ALL=C sed -r -n -e 's/^\#define[ \t]+__NR_([a-z0-9_]+)[ \t]+([0-9]+)(.*)/ [\2] = "\1",/p'
-echo "};")> syscall-names.h
+echo "};"
+echo "#endif")> syscall-names.h

--- a/syscall-reporter.c
+++ b/syscall-reporter.c
@@ -9,12 +9,19 @@
  * The code may be used by anyone for any purpose, and can serve as a
  * starting point for developing applications using mode 2 seccomp.
  */
+#include <signal.h>
+#include <string.h>
+
+#ifdef DEBUG_SECCOMP
 #include "syscall-reporter.h"
+#endif
+
 #include "syscall-names.h"
 
 const char * const msg_needed = "Looks like you also need syscall: ";
 
 /* Since "sprintf" is technically not signal-safe, reimplement %d here. */
+#ifdef SECCOMP
 static void write_uint(char *buf, unsigned int val)
 {
 	int width = 0;
@@ -33,7 +40,6 @@ static void write_uint(char *buf, unsigned int val)
 
 static void reporter(int nr, siginfo_t *info, void *void_context)
 {
-#ifdef SECCOMP
 	char buf[128];
 	ucontext_t *ctx = (ucontext_t *)(void_context);
 	unsigned int syscall;
@@ -53,8 +59,8 @@ static void reporter(int nr, siginfo_t *info, void *void_context)
 	strcat(buf, "\n");
 	write(STDERR_FILENO, buf, strlen(buf));
 	_exit(1);
-#endif
 }
+#endif
 
 int install_syscall_reporter(void)
 {


### PR DESCRIPTION
Port to allow clean build on OSX
Cleanup compiler warnings on later level gcc
Clean build on CentOS7
Fix OpenSSL >= 1.1 compatibility
